### PR TITLE
Support für editheader, cleanup in den Sprachfiles

### DIFF
--- a/dca/tl_photoalbums2_archive.php
+++ b/dca/tl_photoalbums2_archive.php
@@ -79,6 +79,13 @@ $GLOBALS['TL_DCA']['tl_photoalbums2_archive'] = array
 				'icon'                => 'edit.gif',
 				'attributes'          => 'class="contextmenu"'
 			),
+			'editheader' => array
+			(
+				'label'               => &$GLOBALS['TL_LANG']['tl_photoalbums2_archive']['editheader'],
+				'href'                => 'act=edit',
+				'icon'                => 'header.gif',
+				'attributes'          => 'class="edit-header"'
+			),
 			'copy' => array
 			(
 				'label'               => &$GLOBALS['TL_LANG']['tl_photoalbums2_archive']['copy'],

--- a/languages/de/default.php
+++ b/languages/de/default.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -123,5 +123,3 @@ $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['days'] = 'Tag(en)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['weeks'] = 'Woche(n)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['months'] = 'Monat(en)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['years'] = 'Jahr(en)';
-
-?>

--- a/languages/de/modules.php
+++ b/languages/de/modules.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['MOD']['photoalbums2'] = array('Fotoalben', 'Mit diesem Modu
  */
 $GLOBALS['TL_LANG']['FMD']['photoalbums2_legend'] = 'Fotoalben';
 $GLOBALS['TL_LANG']['FMD']['photoalbums2'] = array('Fotoalbum', 'Mit diesem Modul können Sie Ihre Fotoalben im Frontend ausgeben lassen.');
-
-?>

--- a/languages/de/tl_content.php
+++ b/languages/de/tl_content.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -65,5 +65,3 @@ $GLOBALS['TL_LANG']['tl_content']['pa2Image_legend']              = 'Foto Einste
 $GLOBALS['TL_LANG']['tl_content']['pa2Meta_legend']               = 'Meta Einstellungen';
 $GLOBALS['TL_LANG']['tl_content']['pa2TimeFilter_legend']         = 'Zeitfilter';
 $GLOBALS['TL_LANG']['tl_content']['pa2Other_legend']              = 'Sonstiges';
-
-?>

--- a/languages/de/tl_layout.php
+++ b/languages/de/tl_layout.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -33,5 +33,3 @@
  * Fields
  */
 $GLOBALS['TL_LANG']['tl_layout']['skipPhotoalbums2'] = array('Fotoalben Stylesheet ignorieren', 'Ignorieren Sie das Photoalbums2 Standard-Stylesheet, in dem Sie dieses Feld aktivieren.');
-
-?>

--- a/languages/de/tl_module.php
+++ b/languages/de/tl_module.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -82,5 +82,3 @@ $GLOBALS['TL_LANG']['tl_module']['pa2Image_legend']              = 'Foto Einstel
 $GLOBALS['TL_LANG']['tl_module']['pa2Meta_legend']               = 'Meta Einstellungen';
 $GLOBALS['TL_LANG']['tl_module']['pa2TimeFilter_legend']         = 'Zeitfilter';
 $GLOBALS['TL_LANG']['tl_module']['pa2Other_legend']              = 'Sonstiges';
-
-?>

--- a/languages/de/tl_photoalbums2_album.php
+++ b/languages/de/tl_photoalbums2_album.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -78,5 +78,3 @@ $GLOBALS['TL_LANG']['tl_photoalbums2_album']['cut']   = array('Fotoalbum verschi
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['delete'] = array('Fotoalbum löschen', 'Fotoalbum ID %s löschen');
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['show']   = array('Details des Fotoalbum anzeigen', 'Details des Fotoalbum ID %s anzeigen');
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['toggle'] = array('Fotoalbum veröffentlichten/unveröffentlichen', 'Fotoalbum ID %s veröffentlichten/unveröffentlichen');
-
-?>

--- a/languages/de/tl_photoalbums2_archive.php
+++ b/languages/de/tl_photoalbums2_archive.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -77,8 +77,7 @@ $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['notify_both'] = 'Autor und Syste
  */
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['new'] = array('Neues Fotoalben Archiv', 'Neues Fotoalben Archiv erstellen');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['edit'] = array('Fotoalben Archiv bearbeiten', 'Fotoalben Archiv ID %s bearbeiten');
+$GLOBALS['TL_LANG']['tl_photoalbums2_archive']['editheader'] = array('Einstellungen des Fotoalben Archivs bearbeiten', 'Einstellungen des Fotoalben Archivs ID %s bearbeiten');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['copy'] = array('Fotoalben Archiv duplizieren', 'Fotoalben Archiv ID %s duplizieren');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['delete'] = array('Fotoalben Archiv löschen', 'Fotoalben Archiv ID %s löschen');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['show'] = array('Fotoalben Archiv anzeigen', 'Fotoalben Archiv ID %s anzeigen');
-
-?>

--- a/languages/de/tl_user.php
+++ b/languages/de/tl_user.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['tl_user']['photoalbums2p'] = array('Archivrechte', 'Hier kÃ
  * Reference
  */
 $GLOBALS['TL_LANG']['tl_user']['photoalbums2_legend'] = 'Fotoalben-Rechte';
-
-?>

--- a/languages/de/tl_user_group.php
+++ b/languages/de/tl_user_group.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['tl_user_group']['photoalbums2p'] = array('Archivrechte', 'H
  * Reference
  */
 $GLOBALS['TL_LANG']['tl_user_group']['photoalbums2_legend'] = 'Fotoalben-Rechte';
-
-?>

--- a/languages/en/default.php
+++ b/languages/en/default.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -123,5 +123,3 @@ $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['days'] = 'day(s)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['weeks'] = 'week(s)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['months'] = 'month(s)';
 $GLOBALS['TL_LANG']['pa2']['pa2TimeFilterOptions']['years'] = 'year(s)';
-
-?>

--- a/languages/en/modules.php
+++ b/languages/en/modules.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['MOD']['photoalbums2'] = array('Image album', 'With this mod
  */
 $GLOBALS['TL_LANG']['FMD']['photoalbums2_legend'] = 'Image album';
 $GLOBALS['TL_LANG']['FMD']['photoalbums2'] = array('Image album', 'With this module you can display your image albums in the frontend.');
-
-?>

--- a/languages/en/tl_content.php
+++ b/languages/en/tl_content.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -65,5 +65,3 @@ $GLOBALS['TL_LANG']['tl_content']['pa2Image_legend']              = 'Image setti
 $GLOBALS['TL_LANG']['tl_content']['pa2Meta_legend']               = 'Meta settings';
 $GLOBALS['TL_LANG']['tl_content']['pa2TimeFilter_legend']         = 'Time filter settings';
 $GLOBALS['TL_LANG']['tl_content']['pa2Other_legend']              = 'Other';
-
-?>

--- a/languages/en/tl_layout.php
+++ b/languages/en/tl_layout.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -33,5 +33,3 @@
  * Fields
  */
 $GLOBALS['TL_LANG']['tl_layout']['skipPhotoalbums2'] = array('Ignore image album stylesheet', 'By checking this box, you ignore the photoalbums2 default stylesheet.');
-
-?>

--- a/languages/en/tl_module.php
+++ b/languages/en/tl_module.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -82,5 +82,3 @@ $GLOBALS['TL_LANG']['tl_module']['pa2Image_legend']              = 'Image settin
 $GLOBALS['TL_LANG']['tl_module']['pa2Meta_legend']               = 'Meta settings';
 $GLOBALS['TL_LANG']['tl_module']['pa2TimeFilter_legend']         = 'Time filter settings';
 $GLOBALS['TL_LANG']['tl_module']['pa2Other_legend']              = 'Other';
-
-?>

--- a/languages/en/tl_photoalbums2_album.php
+++ b/languages/en/tl_photoalbums2_album.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -78,5 +78,3 @@ $GLOBALS['TL_LANG']['tl_photoalbums2_album']['cut']   = array('Cut image album',
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['delete'] = array('Delete image album', 'Delete image album ID %s');
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['show']   = array('Show details of the image album', 'Show details of the image album ID %s');
 $GLOBALS['TL_LANG']['tl_photoalbums2_album']['toggle'] = array('Publish/unpublish image album', 'Publish/unpublish image album ID %s');
-
-?>

--- a/languages/en/tl_photoalbums2_archive.php
+++ b/languages/en/tl_photoalbums2_archive.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -77,8 +77,7 @@ $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['notify_both'] = 'Author and syst
  */
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['new'] = array('Create new image album archive', 'Create a new image album archive');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['edit'] = array('Edit image album archive', 'Edit the image album archive ID %s');
+$GLOBALS['TL_LANG']['tl_photoalbums2_archive']['editheader'] = array('Edit settings of image album archive', 'Edit settings of the image album archive ID %s');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['copy'] = array('Copy image album archive', 'Copy image album archive ID %s');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['delete'] = array('Delete image album archive', 'Delete image album archive ID %s');
 $GLOBALS['TL_LANG']['tl_photoalbums2_archive']['show'] = array('Show details of the image album archive', 'Show details of the image album archive ID %s');
-
-?>

--- a/languages/en/tl_user.php
+++ b/languages/en/tl_user.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['tl_user']['photoalbums2p'] = array('Archive rights', 'Here 
  * Reference
  */
 $GLOBALS['TL_LANG']['tl_user']['photoalbums2_legend'] = 'Image album rights';
-
-?>

--- a/languages/en/tl_user_group.php
+++ b/languages/en/tl_user_group.php
@@ -1,4 +1,4 @@
-<?php if (!defined('TL_ROOT')) die('You cannot access this file directly!');
+<?php
 
 /**
  * Contao Open Source CMS
@@ -40,5 +40,3 @@ $GLOBALS['TL_LANG']['tl_user_group']['photoalbums2p'] = array('Archive rights', 
  * Reference
  */
 $GLOBALS['TL_LANG']['tl_user_group']['photoalbums2_legend'] = 'Image album rights';
-
-?>


### PR DESCRIPTION
Hi
das ist mein erster Pullrequest hier, also bitte nicht zu streng sein. :-)
Ich habe den editheader Button (und die Sprachverweise) zum DCA hinzugefügt, damit man im Album Archiv nur einmal klicken muss um zu den Einstellungen zu gelangen.

Zusätzlich habe ich diese 

``` php
if (!defined('TL_ROOT')) die('You cannot access this file directly!');
```

Relikte entfernt.
