### PR TITLE
Update tl_module.php

### DIFF
--- a/system/modules/photoalbums2/dca/tl_module.php
+++ b/system/modules/photoalbums2/dca/tl_module.php
@@ -473,7 +473,7 @@ class tl_module_photoalbums2 extends Pa2Backend
      */
     public function getPhotoalbums2Archives()
     {
-        if (!$this->User->isAdmin && !is_array($this->User->photoalbums2_archive)) {
+        if (!$this->User->isAdmin && !is_array($this->User->photoalbums2s)) {
             return array();
         }
 
@@ -482,7 +482,7 @@ class tl_module_photoalbums2 extends Pa2Backend
 
         if ($objArchives !== null) {
             while ($objArchives->next()) {
-                if ($this->User->isAdmin || $this->User->hasAccess($objArchives->id, 'photoalbums2_archive')) {
+                if ($this->User->isAdmin || $this->User->hasAccess($objArchives->id, 'photoalbums2s')) {
                     $arrArchives[$objArchives->id] = $objArchives->title;
                 }
             }


### PR DESCRIPTION
photoalbums2_archive war noch ein veralteter Feldname, in diesem PR habe ich den Namen durch den neuen Namen 'photoalbums2s' ersetzt. Ohne diesen Patch können sonst nur Admins die Archive nutzen.

Grüße
Sioweb
